### PR TITLE
docs(verysmallwoods-video): 选设计时列全目录，别只给两三个选项

### DIFF
--- a/skills_v2/verysmallwoods-video/references/designs.md
+++ b/skills_v2/verysmallwoods-video/references/designs.md
@@ -2,6 +2,8 @@
 
 视频的观感由一个 **frame preset（预制设计）** 决定 - 配色、字体、版式一整套。用户从以下列表选择（默认 BlockFrame）。
 
+> **将以下表格中的设计完整列给用户做选择。**
+
 来源 - https://www.hyperframes.dev/design
 
 ## 目录（slug + 一句风格）


### PR DESCRIPTION
## 背景

在 `verysmallwoods-video` 流水线里，开局会让用户选一个 design（frame preset）。目录本身在 `references/designs.md`，现在还不长（十几个）。

但实际每个 session 里，编排者往往只挑两三个「推荐款」摆给用户，用户看不到全部可选设计。

## 改动

instruction-only 的小改动，让编排者开局就把**完整** design 目录列给用户挑：

- `references/designs.md` - 加一句给编排者的提示：目录不长，开局完整列表，别只挑几个推荐。
- `SKILL.md` - 在「开局问两个选择」那句后面点明：问设计时列全 `references/designs.md` 的目录。

无代码/渲染逻辑变动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)