### PR TITLE
分场景工作流 + storyboard/预览（verysmallwoods-video）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@
 *.wav
 /tmp/
 
+# HyperFrames per-project generated artifacts (regenerable — commit source only)
+.hyperframes/
+.thumbnails/
+snapshots/
+renders/
+
 # python
 __pycache__/
 *.pyc

--- a/demo/claude-showcase/index.html
+++ b/demo/claude-showcase/index.html
@@ -1,15 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=1920, height=1080" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1920, height=1080">
     <title>Claude Warm — Showcase</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,500&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=block"
-      rel="stylesheet"
-    />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,500&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=block" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
     <style>
       * {
@@ -489,125 +486,118 @@
     </style>
   </head>
   <body>
-    <div
-      id="root"
-      data-composition-id="main"
-      data-start="0"
-      data-duration="32"
-      data-width="1920"
-      data-height="1080"
-    >
+    <div data-hf-id="hf-6tfx" id="root" data-composition-id="main" data-start="0" data-duration="32" data-width="1920" data-height="1080">
       <!-- ═══ S1 · COVER ═══ -->
-      <div id="s1" class="scene s-cover">
-        <div class="ghost cv-ghost" aria-hidden="true" data-layout-allow-overlap data-layout-allow-overflow>Warmth</div>
-        <div class="chrome top"><span class="i0 ct"><span class="no">Nº 01</span> &nbsp;/ VI</span><span class="i0 ct">Frontispiece</span></div>
-        <div class="rule r-top" style="top: 128px"></div>
-        <div class="cam">
-          <div class="sage-dots cv-dots" aria-hidden="true">
-            <i class="i0 cvd"></i><i class="i0 cvd"></i><i class="i0 cvd a"></i><i class="i0 cvd"></i><i class="i0 cvd"></i>
-            <i class="i0 cvd"></i><i class="i0 cvd"></i><i class="i0 cvd"></i><i class="i0 cvd"></i><i class="i0 cvd"></i>
-            <i class="i0 cvd"></i><i class="i0 cvd a"></i><i class="i0 cvd"></i><i class="i0 cvd"></i><i class="i0 cvd"></i>
+      <div data-hf-id="hf-rloz" id="s1" class="scene s-cover">
+        <div data-hf-id="hf-imbt" class="ghost cv-ghost" aria-hidden="true" data-layout-allow-overlap="" data-layout-allow-overflow="">Warmth</div>
+        <div data-hf-id="hf-yjv7" class="chrome top"><span data-hf-id="hf-f9y1" class="i0 ct"><span data-hf-id="hf-c53r" class="no">Nº 01</span> &#160;/ VI</span><span data-hf-id="hf-3kos" class="i0 ct">Frontispiece</span></div>
+        <div data-hf-id="hf-qjgo" class="rule r-top" style="top: 128px"></div>
+        <div data-hf-id="hf-12x1" class="cam">
+          <div data-hf-id="hf-inmm" class="sage-dots cv-dots" aria-hidden="true">
+            <i data-hf-id="hf-1716" class="i0 cvd"></i><i data-hf-id="hf-vxtq" class="i0 cvd"></i><i data-hf-id="hf-ep7f" class="i0 cvd a"></i><i data-hf-id="hf-wc4r" class="i0 cvd"></i><i data-hf-id="hf-wqfs" class="i0 cvd"></i>
+            <i data-hf-id="hf-tyal" class="i0 cvd"></i><i data-hf-id="hf-uclm" class="i0 cvd"></i><i data-hf-id="hf-uqwn" class="i0 cvd"></i><i data-hf-id="hf-v57o" class="i0 cvd"></i><i data-hf-id="hf-ypyx" class="i0 cvd"></i>
+            <i data-hf-id="hf-z49y" class="i0 cvd"></i><i data-hf-id="hf-fpej" class="i0 cvd a"></i><i data-hf-id="hf-sw22" class="i0 cvd"></i><i data-hf-id="hf-shr1" class="i0 cvd"></i><i data-hf-id="hf-too4" class="i0 cvd"></i>
           </div>
-          <div class="head">
-            <div class="kicker cv-k i0">Design Preset · No. 16</div>
-            <h1 class="serif">
-              <span class="hl l1 i0">Warmth, calm,</span>
-              <span class="hl l2 i0">and one <span class="accent">terracotta<svg class="ul" viewBox="0 0 320 22" preserveAspectRatio="none" aria-hidden="true"><path class="ulp cv-ulp" d="M4 13 C 70 5, 150 19, 316 9" /></svg></span>.</span>
+          <div data-hf-id="hf-z992" class="head">
+            <div data-hf-id="hf-7s1n" class="kicker cv-k i0">Design Preset · No. 16</div>
+            <h1 data-hf-id="hf-39xx" class="serif">
+              <span data-hf-id="hf-jlx9" class="hl l1 i0">Warmth, calm,</span>
+              <span data-hf-id="hf-qn1n" class="hl l2 i0">and one <span data-hf-id="hf-3ewk" class="accent">terracotta<svg data-hf-id="hf-yayd" class="ul" viewBox="0 0 320 22" preserveAspectRatio="none" aria-hidden="true"><path data-hf-id="hf-ubbq" class="ulp cv-ulp" d="M4 13 C 70 5, 150 19, 316 9" /></svg></span>.</span>
             </h1>
-            <p class="lede cv-lede i0">The Claude design system, rebuilt for the 1920×1080 frame. Parchment paper, a serif that reads like a book, and one warm terracotta.</p>
+            <p data-hf-id="hf-7xxm" class="lede cv-lede i0">The Claude design system, rebuilt for the 1920×1080 frame. Parchment paper, a serif that reads like a book, and one warm terracotta.</p>
           </div>
         </div>
-        <div class="credit i0 cb">After the Anthropic design language · Zürich of the mind · MMXXVI</div>
+        <div data-hf-id="hf-f13t" class="credit i0 cb">After the Anthropic design language · Zürich of the mind · MMXXVI</div>
       </div>
 
       <!-- ═══ S2 · CONTENTS ═══ -->
-      <div id="s2" class="scene s-index">
-        <div class="ghost ix-ghost" aria-hidden="true" data-layout-allow-overlap data-layout-allow-overflow>Index</div>
-        <div class="chrome top"><span><span class="no">Nº 02</span> &nbsp;/ VI</span><span>Contents</span></div>
-        <div class="rule" style="top: 128px"></div>
-        <div class="cam">
-          <div class="head">
-            <div class="kicker ix-k i0">Contents</div>
-            <h2 class="serif ix-h i0">Four warm ideas.</h2>
+      <div data-hf-id="hf-aba1" id="s2" class="scene s-index">
+        <div data-hf-id="hf-kryg" class="ghost ix-ghost" aria-hidden="true" data-layout-allow-overlap="" data-layout-allow-overflow="">Index</div>
+        <div data-hf-id="hf-g3ub" class="chrome top"><span data-hf-id="hf-92gz"><span data-hf-id="hf-bqsq" class="no">Nº 02</span> &#160;/ VI</span><span data-hf-id="hf-bedr">Contents</span></div>
+        <div data-hf-id="hf-zu4g" class="rule" style="top: 128px"></div>
+        <div data-hf-id="hf-wcpl" class="cam">
+          <div data-hf-id="hf-gwvu" class="head">
+            <div data-hf-id="hf-6loj" class="kicker ix-k i0">Contents</div>
+            <h2 data-hf-id="hf-vlq4" class="serif ix-h i0">Four warm ideas.</h2>
           </div>
-          <div class="rows">
-            <div class="r ir i0"><span class="o">01</span><span class="n">A warm foundation</span></div>
-            <div class="r ir on i0"><span class="o">02</span><span class="n">One serif voice<svg class="ul" viewBox="0 0 320 22" preserveAspectRatio="none" aria-hidden="true" style="bottom: 0.1em"><path class="ulp ix-ulp" d="M4 13 C 70 6, 150 18, 316 9" /></svg></span></div>
-            <div class="r ir i0"><span class="o">03</span><span class="n">Terracotta, sparingly</span></div>
-            <div class="r ir i0"><span class="o">04</span><span class="n">Generous negative space</span></div>
+          <div data-hf-id="hf-hnc7" class="rows">
+            <div data-hf-id="hf-oumm" class="r ir i0"><span data-hf-id="hf-7gn7" class="o">01</span><span data-hf-id="hf-31xu" class="n">A warm foundation</span></div>
+            <div data-hf-id="hf-y709" class="r ir on i0"><span data-hf-id="hf-72c6" class="o">02</span><span data-hf-id="hf-6jjc" class="n">One serif voice<svg data-hf-id="hf-ozjt" class="ul" viewBox="0 0 320 22" preserveAspectRatio="none" aria-hidden="true" style="bottom: 0.1em"><path data-hf-id="hf-dmdk" class="ulp ix-ulp" d="M4 13 C 70 6, 150 18, 316 9" /></svg></span></div>
+            <div data-hf-id="hf-jwnm" class="r ir i0"><span data-hf-id="hf-6o15" class="o">03</span><span data-hf-id="hf-qlt5" class="n">Terracotta, sparingly</span></div>
+            <div data-hf-id="hf-kayn" class="r ir i0"><span data-hf-id="hf-69q4" class="o">04</span><span data-hf-id="hf-n10g" class="n">Generous negative space</span></div>
           </div>
         </div>
       </div>
 
       <!-- ═══ S3 · PULL-QUOTE ═══ -->
-      <div id="s3" class="scene s-quote">
-        <div class="ghost qg-ghost" aria-hidden="true" data-layout-allow-overlap data-layout-allow-overflow>Voice</div>
-        <div class="chrome top"><span><span class="no">Nº 03</span> &nbsp;/ VI</span><span>The Voice</span></div>
-        <div class="rule" style="top: 128px"></div>
-        <div class="cam">
-          <div class="mark qm i0" aria-hidden="true" data-layout-allow-overlap>“</div>
-          <div class="head">
-            <h2 class="serif">
-              <span class="hl ql1 i0">Good taste,</span>
-              <span class="hl ql2 i0">made <em>legible<svg class="ul" viewBox="0 0 320 22" preserveAspectRatio="none" aria-hidden="true"><path class="ulp q-ulp" d="M4 12 C 70 5, 150 18, 316 8" /></svg></em>.</span>
+      <div data-hf-id="hf-s8rc" id="s3" class="scene s-quote">
+        <div data-hf-id="hf-hegd" class="ghost qg-ghost" aria-hidden="true" data-layout-allow-overlap="" data-layout-allow-overflow="">Voice</div>
+        <div data-hf-id="hf-fpja" class="chrome top"><span data-hf-id="hf-jk8z"><span data-hf-id="hf-bchp" class="no">Nº 03</span> &#160;/ VI</span><span data-hf-id="hf-2pwa">The Voice</span></div>
+        <div data-hf-id="hf-vad4" class="rule" style="top: 128px"></div>
+        <div data-hf-id="hf-xjmo" class="cam">
+          <div data-hf-id="hf-3i31" class="mark qm i0" aria-hidden="true" data-layout-allow-overlap="">“</div>
+          <div data-hf-id="hf-hb6v" class="head">
+            <h2 data-hf-id="hf-2nqi" class="serif">
+              <span data-hf-id="hf-qmzm" class="hl ql1 i0">Good taste,</span>
+              <span data-hf-id="hf-2vea" class="hl ql2 i0">made <em data-hf-id="hf-rmsp">legible<svg data-hf-id="hf-kg15" class="ul" viewBox="0 0 320 22" preserveAspectRatio="none" aria-hidden="true"><path data-hf-id="hf-xbeh" class="ulp q-ulp" d="M4 12 C 70 5, 150 18, 316 8" /></svg></em>.</span>
             </h2>
           </div>
-          <div class="att qa i0">The Claude design system</div>
+          <div data-hf-id="hf-ds6g" class="att qa i0">The Claude design system</div>
         </div>
       </div>
 
       <!-- ═══ S4 · STAT ═══ -->
-      <div id="s4" class="scene s-stat">
-        <div class="ghost sg-ghost" aria-hidden="true" data-layout-allow-overlap data-layout-allow-overflow>Paper</div>
-        <div class="chrome top"><span><span class="no">Nº 04</span> &nbsp;/ VI</span><span>The Feeling</span></div>
-        <div class="rule" style="top: 128px"></div>
-        <div class="cam">
-          <div class="kicker st-k i0">More like paper</div>
-          <div class="fig serif i0"><span id="figv">0.0</span>×</div>
-          <div class="side st-side">
-            <h3 class="i0">The reading comfort of a printed page.</h3>
-            <p class="i0">Where most AI pages lean cold and futuristic, this one radiates human warmth — as if the interface itself has good taste.</p>
+      <div data-hf-id="hf-5331" id="s4" class="scene s-stat">
+        <div data-hf-id="hf-36xr" class="ghost sg-ghost" aria-hidden="true" data-layout-allow-overlap="" data-layout-allow-overflow="">Paper</div>
+        <div data-hf-id="hf-fb89" class="chrome top"><span data-hf-id="hf-j5xy"><span data-hf-id="hf-e4mw" class="no">Nº 04</span> &#160;/ VI</span><span data-hf-id="hf-d478">The Feeling</span></div>
+        <div data-hf-id="hf-u3g1" class="rule" style="top: 128px"></div>
+        <div data-hf-id="hf-x5bn" class="cam">
+          <div data-hf-id="hf-jhdr" class="kicker st-k i0">More like paper</div>
+          <div data-hf-id="hf-s2n9" class="fig serif i0"><span data-hf-id="hf-pt6k" id="figv">0.0</span>×</div>
+          <div data-hf-id="hf-f85q" class="side st-side">
+            <h3 data-hf-id="hf-ayap" class="i0">The reading comfort of a printed page.</h3>
+            <p data-hf-id="hf-j41c" class="i0">Where most AI pages lean cold and futuristic, this one radiates human warmth — as if the interface itself has good taste.</p>
           </div>
         </div>
       </div>
 
       <!-- ═══ S5 · EDITORIAL ═══ -->
-      <div id="s5" class="scene s-edit">
-        <div class="ghost eg-ghost" aria-hidden="true" data-layout-allow-overlap data-layout-allow-overflow>Book</div>
-        <div class="chrome top"><span><span class="no">Nº 05</span> &nbsp;/ VI</span><span>The Layout</span></div>
-        <div class="rule" style="top: 128px"></div>
-        <div class="cam">
-          <div class="txt">
-            <div class="kicker ed-k i0">A companion, not a tool</div>
-            <h2 class="ed-h i0">Every heading has the gravitas of a book title.</h2>
-            <p class="ed-p i0">The serif breathes at a <span class="underline">tight-but-comfortable<svg class="ul" viewBox="0 0 320 18" preserveAspectRatio="none" aria-hidden="true" style="bottom: -0.1em"><path class="ulp ed-ulp" d="M3 10 C 70 4, 150 14, 317 7" /></svg></span> cadence; the body sets in a humanist sans, and the terracotta appears only where it earns attention.</p>
+      <div data-hf-id="hf-k7gm" id="s5" class="scene s-edit">
+        <div data-hf-id="hf-ot6o" class="ghost eg-ghost" aria-hidden="true" data-layout-allow-overlap="" data-layout-allow-overflow="">Book</div>
+        <div data-hf-id="hf-ewx8" class="chrome top"><span data-hf-id="hf-irmx"><span data-hf-id="hf-dqbv" class="no">Nº 05</span> &#160;/ VI</span><span data-hf-id="hf-gfqe">The Layout</span></div>
+        <div data-hf-id="hf-uhr2" class="rule" style="top: 128px"></div>
+        <div data-hf-id="hf-v5si" class="cam">
+          <div data-hf-id="hf-kvio" class="txt">
+            <div data-hf-id="hf-h2zy" class="kicker ed-k i0">A companion, not a tool</div>
+            <h2 data-hf-id="hf-6o28" class="ed-h i0">Every heading has the gravitas of a book title.</h2>
+            <p data-hf-id="hf-nc16" class="ed-p i0">The serif breathes at a <span data-hf-id="hf-4kra" class="underline">tight-but-comfortable<svg data-hf-id="hf-hqmf" class="ul" viewBox="0 0 320 18" preserveAspectRatio="none" aria-hidden="true" style="bottom: -0.1em"><path data-hf-id="hf-kikz" class="ulp ed-ulp" d="M3 10 C 70 4, 150 14, 317 7" /></svg></span> cadence; the body sets in a humanist sans, and the terracotta appears only where it earns attention.</p>
           </div>
-          <div class="card ed-card i0">
-            <div class="ph"><div class="glyph"></div></div>
+          <div data-hf-id="hf-b40r" class="card ed-card i0">
+            <div data-hf-id="hf-i8mw" class="ph"><div data-hf-id="hf-4k1m" class="glyph"></div></div>
           </div>
         </div>
       </div>
 
       <!-- ═══ S6 · CLOSING ═══ -->
-      <div id="s6" class="scene s-close">
-        <div class="leak cl-leak" aria-hidden="true"></div>
-        <div class="ghost cg-ghost" aria-hidden="true" data-layout-allow-overlap data-layout-allow-overflow>Fin</div>
-        <div class="chrome top"><span><span class="no">Nº 06</span> &nbsp;/ VI</span><span>Colophon</span></div>
-        <div class="cam">
-          <div class="sage-dots cl-dots" aria-hidden="true">
-            <i class="i0 cld"></i><i class="i0 cld a"></i><i class="i0 cld"></i><i class="i0 cld"></i><i class="i0 cld"></i>
-            <i class="i0 cld"></i><i class="i0 cld"></i><i class="i0 cld"></i><i class="i0 cld a"></i><i class="i0 cld"></i>
+      <div data-hf-id="hf-bs1h" id="s6" class="scene s-close">
+        <div data-hf-id="hf-tfx7" class="leak cl-leak" aria-hidden="true"></div>
+        <div data-hf-id="hf-orvo" class="ghost cg-ghost" aria-hidden="true" data-layout-allow-overlap="" data-layout-allow-overflow="">Fin</div>
+        <div data-hf-id="hf-eim7" class="chrome top"><span data-hf-id="hf-idbw"><span data-hf-id="hf-dc0u" class="no">Nº 06</span> &#160;/ VI</span><span data-hf-id="hf-q48v">Colophon</span></div>
+        <div data-hf-id="hf-urhh" class="cam">
+          <div data-hf-id="hf-02sc" class="sage-dots cl-dots" aria-hidden="true">
+            <i data-hf-id="hf-bd7o" class="i0 cld"></i><i data-hf-id="hf-0jn1" class="i0 cld a"></i><i data-hf-id="hf-0lss" class="i0 cld"></i><i data-hf-id="hf-zevp" class="i0 cld"></i><i data-hf-id="hf-zt6q" class="i0 cld"></i>
+            <i data-hf-id="hf-1spv" class="i0 cld"></i><i data-hf-id="hf-270w" class="i0 cld"></i><i data-hf-id="hf-103t" class="i0 cld"></i><i data-hf-id="hf-nyu9" class="i0 cld a"></i><i data-hf-id="hf-1eeu" class="i0 cld"></i>
           </div>
-          <div class="head">
-            <h2 class="serif">
-              <span class="hl cl1 i0">Serve the reader</span>
-              <span class="hl cl2 i0"><em>warmly</em>.</span>
+          <div data-hf-id="hf-hphw" class="head">
+            <h2 data-hf-id="hf-53se" class="serif">
+              <span data-hf-id="hf-rmex" class="hl cl1 i0">Serve the reader</span>
+              <span data-hf-id="hf-x4yj" class="hl cl2 i0"><em data-hf-id="hf-sksh">warmly</em>.</span>
             </h2>
           </div>
-          <div class="meta cl-meta i0">claude-warm · HyperFrames</div>
+          <div data-hf-id="hf-hfiq" class="meta cl-meta i0">claude-warm · HyperFrames</div>
         </div>
       </div>
-      <div class="watermark" aria-hidden="true"><span class="wm-dot"></span>Boring Video Studio</div>
+      <div data-hf-id="hf-onkf" class="watermark" aria-hidden="true"><span data-hf-id="hf-xqkv" class="wm-dot"></span>Boring Video Studio</div>
     </div>
 
     <script>

--- a/demo/storyboard-demo/STORYBOARD.md
+++ b/demo/storyboard-demo/STORYBOARD.md
@@ -1,0 +1,44 @@
+---
+format: 1920x1080
+duration: 20s
+message: "一支视频拆成独立场景，各自调校，再拼成整片"
+arc: Hook → Concept → CTA
+audience: 想试 HyperFrames Studio 分场景工作流的人
+mode: collaborative
+---
+
+## Frame 1 — Hook
+
+- scene: 大标题在暖色纸面上打入，副标题跟进
+- duration: 6s
+- poster: 3s
+- transition_in: cut
+- status: animated
+- voiceover: "长视频，不必一次渲染到底。"
+- src: compositions/frames/01-hook.html
+
+开场抛出主张：把一整支视频拆成独立的场景（子合成），每个都能单独生成、单独预览、单独定稿。
+
+## Frame 2 — Concept
+
+- scene: 三块「场景卡」依次落位，拼成一条时间线
+- duration: 8s
+- poster: 5s
+- transition_in: crossfade
+- status: animated
+- voiceover: "每个场景是一个文件。改第二个，不用重渲第一、第三个。"
+- src: compositions/frames/02-concept.html
+
+核心概念：宿主只负责在时间线上编排；每个场景卡是独立子合成文件，改一处不牵动全片。
+
+## Frame 3 — CTA
+
+- scene: 收束到一行结论，强调「拼装」
+- duration: 6s
+- poster: 3s
+- transition_in: crossfade
+- status: animated
+- voiceover: "分开打磨，再拼到一起。"
+- src: compositions/frames/03-cta.html
+
+收尾：先分后合的工作流，在 Studio 里逐场景审、逐帧评论、装配成片。

--- a/demo/storyboard-demo/compositions/frames/01-hook.html
+++ b/demo/storyboard-demo/compositions/frames/01-hook.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <!-- head 只是源文件的元数据；被宿主挂载时整个 head 会被丢弃。
+         gsap 由宿主提供。此处的 script 仅便于单独渲染该文件时也能用。 -->
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+  </head>
+  <body>
+    <template>
+      <style>
+        /* 根节点必须用 #root 选择器，不能用 class —— 合成时 CSS 会被
+           scope 到 data-composition-id，根节点的 class 规则会被静默丢掉。 */
+        #root {
+          position: absolute;
+          inset: 0;
+          overflow: hidden;
+          background: #f5f4ed;
+          font-family: "EB Garamond", Georgia, "Times New Roman", serif;
+          color: #141413;
+          --accent: #c96442;
+        }
+        #root .kicker {
+          position: absolute;
+          top: 180px;
+          left: 224px;
+          font-family: "Inter", system-ui, sans-serif;
+          font-size: 30px;
+          letter-spacing: 8px;
+          text-transform: uppercase;
+          color: var(--accent);
+        }
+        /* 主角：长视频 —— 超大、暖橙、擦除揭幕 */
+        #root .big {
+          position: absolute;
+          top: 300px;
+          left: 210px;
+          font-size: 260px;
+          line-height: 1;
+          font-weight: 600;
+          letter-spacing: 4px;
+          color: var(--accent);
+          white-space: nowrap;
+        }
+        #root .rest {
+          position: absolute;
+          top: 660px;
+          left: 220px;
+          font-size: 104px;
+          line-height: 1.02;
+          font-weight: 500;
+          color: #141413;
+        }
+        #root .rule {
+          position: absolute;
+          top: 818px;
+          left: 226px;
+          width: 520px;
+          height: 3px;
+          background: var(--accent);
+          transform-origin: left center;
+        }
+        #root .sub {
+          position: absolute;
+          top: 854px;
+          left: 226px;
+          font-family: "Inter", system-ui, sans-serif;
+          font-size: 38px;
+          color: #5e5d59;
+        }
+      </style>
+
+      <div data-hf-id="hf-hv3x" id="root" data-composition-id="s1-hook" data-width="1920" data-height="1080">
+        <div data-hf-id="hf-lvjk" class="kicker">SCENE 01 · HOOK</div>
+        <div data-hf-id="hf-f5fa" class="big">长视频</div>
+        <div data-hf-id="hf-sd2f" class="rest">不必一次渲染到底</div>
+        <div data-hf-id="hf-a46i" class="rule"></div>
+        <div data-hf-id="hf-qjhl" class="sub">把一支视频拆成独立场景，各自打磨。</div>
+      </div>
+
+      <script>
+        window.__timelines = window.__timelines || {};
+        const tl = gsap.timeline({ paused: true, defaults: { ease: "power2.out" } });
+        tl.fromTo("#root .kicker", { opacity: 0, y: 20 }, { opacity: 1, y: 0, duration: 0.6 }, 0.1);
+        // 长视频：从左到右擦除揭幕 + 轻微回落，作为视觉主角
+        tl.fromTo(
+          "#root .big",
+          { clipPath: "inset(0 100% 0 0)", opacity: 1, y: 12, scale: 1.03 },
+          { clipPath: "inset(0 0% 0 0)", y: 0, scale: 1, duration: 1.15, ease: "power3.out" },
+          0.3
+        );
+        tl.fromTo("#root .rest", { opacity: 0, y: 40 }, { opacity: 1, y: 0, duration: 0.85 }, 1.2);
+        tl.fromTo("#root .rule", { scaleX: 0 }, { scaleX: 1, duration: 0.7, ease: "power1.out" }, 1.55);
+        tl.fromTo("#root .sub", { opacity: 0, y: 24 }, { opacity: 1, y: 0, duration: 0.7 }, 1.7);
+        tl.to({}, { duration: 6 }, 0);
+        window.__timelines["s1-hook"] = tl;
+      </script>
+    </template>
+  </body>
+</html>

--- a/demo/storyboard-demo/compositions/frames/02-concept.html
+++ b/demo/storyboard-demo/compositions/frames/02-concept.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+  </head>
+  <body>
+    <template>
+      <style>
+        #root {
+          position: absolute;
+          inset: 0;
+          overflow: hidden;
+          background: #f5f4ed;
+          font-family: "Inter", system-ui, sans-serif;
+          color: #141413;
+          --accent: #c96442;
+          --ink-soft: #5e5d59;
+          --serif: "EB Garamond", Georgia, serif;
+        }
+        #root .kicker {
+          position: absolute;
+          top: 150px;
+          left: 220px;
+          font-size: 30px;
+          letter-spacing: 8px;
+          text-transform: uppercase;
+          color: var(--accent);
+        }
+        #root .head {
+          position: absolute;
+          top: 210px;
+          left: 216px;
+          font-family: var(--serif);
+          font-size: 92px;
+          font-weight: 500;
+        }
+        #root .rail {
+          position: absolute;
+          top: 812px;
+          left: 220px;
+          width: 1480px;
+          height: 4px;
+          background: #e0ded2;
+          transform-origin: left center;
+        }
+        #root .cards {
+          position: absolute;
+          top: 400px;
+          left: 220px;
+          display: flex;
+          gap: 60px;
+        }
+        #root .card {
+          width: 440px;
+          height: 300px;
+          background: #faf9f5;
+          border: 1px solid #e8e6dc;
+          border-radius: 20px;
+          padding: 44px;
+          box-shadow: 0 24px 60px rgba(20, 20, 19, 0.06);
+        }
+        #root .card .n {
+          font-family: var(--serif);
+          font-size: 64px;
+          color: var(--accent);
+          line-height: 1;
+        }
+        #root .card .t {
+          margin-top: 26px;
+          font-size: 40px;
+          font-weight: 600;
+        }
+        #root .card .d {
+          margin-top: 16px;
+          font-size: 27px;
+          line-height: 1.5;
+          color: var(--ink-soft);
+        }
+        #root .dot {
+          position: absolute;
+          top: 799px;
+          width: 26px;
+          height: 26px;
+          border-radius: 50%;
+          background: var(--accent);
+        }
+      </style>
+
+      <div data-hf-id="hf-okoz" id="root" data-composition-id="s2-concept" data-width="1920" data-height="1080">
+        <div data-hf-id="hf-yhvc" class="kicker">SCENE 02 · CONCEPT</div>
+        <div data-hf-id="hf-v23s" class="head">三个场景，拼成一条时间线</div>
+        <div data-hf-id="hf-5cwd" class="cards">
+          <div data-hf-id="hf-z0sh" class="card" data-i="0">
+            <div data-hf-id="hf-7h2p" class="n">01</div>
+            <div data-hf-id="hf-7b70" class="t">独立文件</div>
+            <div data-hf-id="hf-jgsw" class="d">每个场景是一个 HTML 子合成，单独生成、单独预览。</div>
+          </div>
+          <div data-hf-id="hf-y94o" class="card" data-i="1">
+            <div data-hf-id="hf-8nzs" class="n">02</div>
+            <div data-hf-id="hf-x1fs" class="t">互不牵动</div>
+            <div data-hf-id="hf-zv6a" class="d">改第二个场景，不用重渲第一、第三个。</div>
+          </div>
+          <div data-hf-id="hf-6x0j" class="card" data-i="2">
+            <div data-hf-id="hf-89or" class="n">03</div>
+            <div data-hf-id="hf-m8x2" class="t">宿主编排</div>
+            <div data-hf-id="hf-2l1t" class="d">index.html 只负责把它们摆到时间线上。</div>
+          </div>
+        </div>
+        <div data-hf-id="hf-qzq8" class="rail"></div>
+        <div data-hf-id="hf-s1yq" class="dot" data-i="0" style="left: 427px"></div>
+        <div data-hf-id="hf-wbbq" class="dot" data-i="1" style="left: 927px"></div>
+        <div data-hf-id="hf-e1o5" class="dot" data-i="2" style="left: 1427px"></div>
+      </div>
+
+      <script>
+        window.__timelines = window.__timelines || {};
+        const tl = gsap.timeline({ paused: true, defaults: { ease: "power2.out" } });
+        tl.fromTo("#root .kicker", { opacity: 0, y: 20 }, { opacity: 1, y: 0, duration: 0.6 }, 0.1);
+        tl.fromTo("#root .head", { opacity: 0, y: 34 }, { opacity: 1, y: 0, duration: 0.8 }, 0.3);
+        tl.fromTo("#root .rail", { scaleX: 0 }, { scaleX: 1, duration: 1.0, ease: "power1.out" }, 0.7);
+
+        // 卡片与对应节点严格同步：card[i] 和 dot[i] 在同一时间点入场。
+        // 放慢：每对间隔 1.2s，卡片入场时长 1.0s。
+        const START = 1.6;
+        const GAP = 1.2;
+        for (let i = 0; i < 3; i++) {
+          const t = START + i * GAP;
+          tl.fromTo(
+            "#root .card[data-i='" + i + "']",
+            { opacity: 0, y: 60 },
+            { opacity: 1, y: 0, duration: 1.0 },
+            t
+          );
+          tl.fromTo(
+            "#root .dot[data-i='" + i + "']",
+            { scale: 0, opacity: 0 },
+            { scale: 1, opacity: 1, duration: 0.6, ease: "back.out(2)" },
+            t
+          );
+        }
+
+        tl.to({}, { duration: 8 }, 0);
+        window.__timelines["s2-concept"] = tl;
+      </script>
+    </template>
+  </body>
+</html>

--- a/demo/storyboard-demo/compositions/frames/03-cta.html
+++ b/demo/storyboard-demo/compositions/frames/03-cta.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+  </head>
+  <body>
+    <template>
+      <style>
+        #root {
+          position: absolute;
+          inset: 0;
+          overflow: hidden;
+          background: #1f1d1a;
+          font-family: "EB Garamond", Georgia, serif;
+          color: #f5f4ed;
+          --accent: #d97757;
+        }
+        /* 标题几何：基础层与高亮层共用，保证完全重合 */
+        #root .headline {
+          position: absolute;
+          top: 420px;
+          left: 220px;
+          font-size: 128px;
+          font-weight: 500;
+          line-height: 1.05;
+        }
+        #root .base .accent {
+          color: var(--accent);
+        }
+        /* 高亮层：一条明亮暖光带，跟随背景光带扫过文字，产生透光感 */
+        #root .glow {
+          --p: -0.15;
+          color: #ffe9d8;
+          text-shadow: 0 0 24px rgba(255, 180, 130, 0.9), 0 0 8px rgba(255, 214, 176, 0.7);
+          mix-blend-mode: screen;
+          pointer-events: none;
+          /* 以 --p (0→1) 为中心的 18% 竖直亮带，从左到右移动 */
+          clip-path: inset(
+            0 calc((1 - var(--p)) * 100% - 9%) 0 calc(var(--p) * 100% - 9%)
+          );
+        }
+        #root .meta {
+          position: absolute;
+          top: 700px;
+          left: 224px;
+          display: flex;
+          align-items: center;
+          gap: 20px;
+          font-family: "Inter", system-ui, sans-serif;
+          font-size: 34px;
+          letter-spacing: 4px;
+          color: #a8a49a;
+        }
+        #root .meta .ar {
+          color: var(--accent);
+          font-size: 38px;
+        }
+        #root .leak {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 500px;
+          height: 1080px;
+          background: linear-gradient(
+            90deg,
+            rgba(217, 119, 87, 0) 0%,
+            rgba(217, 119, 87, 0.4) 50%,
+            rgba(217, 119, 87, 0) 100%
+          );
+          filter: blur(40px);
+          pointer-events: none;
+        }
+      </style>
+
+      <div data-hf-id="hf-ly12" id="root" data-composition-id="s3-cta" data-width="1920" data-height="1080">
+        <div data-hf-id="hf-mggd" class="leak"></div>
+        <div data-hf-id="hf-op42" class="headline base">分开打磨，<br data-hf-id="hf-x5px"><span data-hf-id="hf-f3xf" class="accent">再拼到一起。</span></div>
+        <div data-hf-id="hf-3qp3" class="headline glow" aria-hidden="true">分开打磨，<br data-hf-id="hf-rsrt">再拼到一起。</div>
+        <div data-hf-id="hf-puvz" class="meta">
+          <span data-hf-id="hf-bknn" class="w">STORYBOARD</span>
+          <span data-hf-id="hf-08ha" class="ar">→</span>
+          <span data-hf-id="hf-ue5l" class="w">SCENES</span>
+          <span data-hf-id="hf-wliq" class="ar">→</span>
+          <span data-hf-id="hf-j7vc" class="w">ASSEMBLE</span>
+        </div>
+      </div>
+
+      <script>
+        window.__timelines = window.__timelines || {};
+        const tl = gsap.timeline({ paused: true, defaults: { ease: "power2.out" } });
+
+        // 背景光带从左到右横扫
+        tl.fromTo(
+          "#root .leak",
+          { x: -500, opacity: 0 },
+          { x: 400, opacity: 1, duration: 1.8, ease: "sine.inOut" },
+          0.3
+        );
+        tl.to("#root .leak", { x: 1600, opacity: 0, duration: 2.0, ease: "sine.inOut" }, 2.2);
+
+        // 标题基础层：左→右擦除揭幕，与背景横扫同向
+        tl.fromTo(
+          "#root .base",
+          { clipPath: "inset(0 100% 0 0)", y: 18 },
+          { clipPath: "inset(0 0% 0 0)", y: 0, duration: 1.6, ease: "power2.inOut" },
+          0.3
+        );
+
+        // 高亮层：亮带随背景光带同步扫过文字，透光感
+        tl.fromTo(
+          "#root .glow",
+          { "--p": -0.15 },
+          { "--p": 1.15, duration: 2.4, ease: "sine.inOut" },
+          0.4
+        );
+
+        // 元数据：STORYBOARD → SCENES → ASSEMBLE 按文档顺序逐个依次出现
+        // （词、箭头、词、箭头、词 —— 严格顺序，不是先词后箭头）
+        tl.fromTo(
+          "#root .meta > *",
+          { opacity: 0, y: 14 },
+          { opacity: 1, y: 0, duration: 0.5, stagger: 0.4, ease: "power2.out" },
+          1.9
+        );
+
+        tl.to({}, { duration: 6 }, 0);
+        window.__timelines["s3-cta"] = tl;
+      </script>
+    </template>
+  </body>
+</html>

--- a/demo/storyboard-demo/hyperframes.json
+++ b/demo/storyboard-demo/hyperframes.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hyperframes.json",
+  "registry": "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+  "paths": {
+    "blocks": "compositions",
+    "components": "compositions/components",
+    "assets": "assets"
+  },
+  "media": {
+    "autoProxy": true
+  }
+}

--- a/demo/storyboard-demo/index.html
+++ b/demo/storyboard-demo/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1920, height=1080">
+    <title>Storyboard Demo — 分场景工作流</title>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #f5f4ed;
+      }
+      #root {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+        background: #f5f4ed;
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      宿主只做编排：三个场景各是一个独立子合成文件。
+      每个槽的 data-composition-id 必须与子文件内部的 data-composition-id
+      以及 window.__timelines[...] 的 key 完全一致。
+    -->
+    <div data-hf-id="hf-at0g" id="root" data-composition-id="main" data-start="0" data-duration="20" data-width="1920" data-height="1080">
+      <div data-hf-id="hf-tkvz" id="scene-1-hook" data-composition-id="s1-hook" data-composition-src="compositions/frames/01-hook.html" data-start="0" data-duration="6" data-track-index="0" data-width="1920" data-height="1080"></div>
+
+      <div data-hf-id="hf-gimz" id="scene-2-concept" data-composition-id="s2-concept" data-composition-src="compositions/frames/02-concept.html" data-start="6" data-duration="8" data-track-index="0" data-width="1920" data-height="1080"></div>
+
+      <div data-hf-id="hf-cn29" id="scene-3-cta" data-composition-id="s3-cta" data-composition-src="compositions/frames/03-cta.html" data-start="14" data-duration="6" data-track-index="0" data-width="1920" data-height="1080"></div>
+    </div>
+
+    <script>
+      // 宿主自己的时间线只定义整片长度；子合成由运行时独立驱动，
+      // 不要 master.add(child)，否则会双重 seek。
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.to({}, { duration: 20 }, 0);
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>

--- a/demo/storyboard-demo/meta.json
+++ b/demo/storyboard-demo/meta.json
@@ -1,0 +1,5 @@
+{
+  "id": "storyboard-demo",
+  "name": "storyboard-demo",
+  "createdAt": "2026-08-05T00:00:00.000Z"
+}

--- a/demo/storyboard-demo/package.json
+++ b/demo/storyboard-demo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "storyboard-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "npx --yes hyperframes preview",
+    "check": "npx --yes hyperframes check",
+    "render": "npx --yes hyperframes render",
+    "publish": "npx --yes hyperframes publish"
+  }
+}

--- a/skills/verysmallwoods-video/SKILL.md
+++ b/skills/verysmallwoods-video/SKILL.md
@@ -32,12 +32,12 @@ description: 小木头的个人视频流水线。基于一个主题，一篇文�
 一个选题 = 一个项目目录（当前工作目录下，命名 `<YYYYMMDD-slug>`）
 
 - Step 0 · 定选题、问两个选择（设计 + 旁白来源）→ `references/designs.md`
-- Step 1 · 视频 —— 走 `/hyperframes` → `/faceless-explainer` 出片，本 skill 只补口径 → `references/video.md`
+- Step 1 · 视频 —— 走 `/hyperframes` → `/faceless-explainer` 出片，本 skill 只补口径；**每期必建 STORYBOARD.md（含单场景，不许跳过）** → `references/video.md`
 - Step 2 · 旁白接入 → `references/audio.md`
 - Step 3 · 生成五比例封面 → `references/covers.md`
 - Step 4 · 生成平台文案 → `references/platform-copy.md`
 - Step 5 · 博客 + 推文 → `references/blog-and-tweet.md`
-- Step 6 · 验收 + 渲染 - 对交付清单逐项核，1080p 先出、再出 4K master
+- Step 6 · 验收 + 渲染 - 对交付清单逐项核；**渲染前必问用户是否 Studio 预览**（不要 → 跳过；要 → 启动预览服务、交 URL、等反馈），确认后 1080p 先出、再出 4K master
 
 ## 参考
 

--- a/skills/verysmallwoods-video/SKILL.md
+++ b/skills/verysmallwoods-video/SKILL.md
@@ -32,12 +32,12 @@ description: 小木头的个人视频流水线。基于一个主题，一篇文�
 一个选题 = 一个项目目录（当前工作目录下，命名 `<YYYYMMDD-slug>`）
 
 - Step 0 · 定选题、问两个选择（设计 + 旁白来源）→ `references/designs.md`
-- Step 1 · 视频 —— 走 `/hyperframes` → `/faceless-explainer` 出片，本 skill 只补口径；**每期必建 STORYBOARD.md（含单场景，不许跳过）** → `references/video.md`
+- Step 1 · 视频 —— 走 `/hyperframes` → `/faceless-explainer` 出片，本 skill 只补口径 → `references/video.md`
 - Step 2 · 旁白接入 → `references/audio.md`
 - Step 3 · 生成五比例封面 → `references/covers.md`
 - Step 4 · 生成平台文案 → `references/platform-copy.md`
 - Step 5 · 博客 + 推文 → `references/blog-and-tweet.md`
-- Step 6 · 验收 + 渲染 - 对交付清单逐项核；**渲染前必问用户是否 Studio 预览**（不要 → 跳过；要 → 启动预览服务、交 URL、等反馈），确认后 1080p 先出、再出 4K master
+- Step 6 · 验收 + 渲染 - 对交付清单逐项核，1080p 先出、再出 4K master
 
 ## 参考
 

--- a/skills/verysmallwoods-video/references/video.md
+++ b/skills/verysmallwoods-video/references/video.md
@@ -22,10 +22,12 @@
 
 本 skill 在其上只补几条 faceless 没有的**用户口径**：
 
+- **STORYBOARD 必建（铁律）** —— 每期视频都要写 `STORYBOARD.md`，**哪怕只有一个场景**。它是分场景审校与「改一处不重渲全片」的计划账本：一格一个 frame，Studio 渲成联系表可逐帧审、逐帧评论（`.hyperframes/frame-comments.json`）。faceless 里它可能被当作可选或对单场景省略 —— 本 skill 把它收成硬约定，不许跳过。格式见 `/hyperframes-core` 的 `references/storyboard-format.md`。
 - **设计** —— 用 Step 0 选定的 preset（默认 `blockframe`），见 `references/designs.md`。
 - **口播稿** —— 按用户的写作/口播偏好写；偏好来自上下文 / 记忆 / 会话里的风格 skill。
 - **旁白** —— 见 `references/audio.md`（自录 或 TTS，由用户选）。
 - **重排到真实 cue** —— 拿到真实音频 + SRT 后，把每帧内部披露重排到真实 cue 时间轴；否则动效走完会定格、旁白在静态画面上继续讲。做法见 `references/audio.md`。
+- **预览 —— 渲染前必问（铁律）** —— `check` 通过后、渲染前，**显式询问用户是否要在 Studio 预览**。用户不要预览 → 跳过，直接进渲染；用户要预览 → 启动 `npx hyperframes preview`（后台常驻），把 Studio URL 交给用户：整片走 `http://localhost:<port>/#project/<name>`，看 storyboard 联系表走 `http://localhost:<port>/?view=storyboard#project/<name>`。等用户看完给反馈（改则读 `frame-comments.json` 走修订轮，见「STORYBOARD 必建」）再渲染。**不要 check 一过就自动渲染。**
 - **字幕不烧进成片** —— 用户在 YouTube 上字幕；成片留底部字幕安全区即可。
 - **帧率** —— 按动效规格智能判定，报给用户，可被指定覆盖。判定后告知用户：选择的帧率，依据以及不同帧率对视频产出的影响。用户明确指定帧率时以用户为准。
 - **渲染** —— 1080p{fps} high 先出保底，磁盘够再出 4K master（`--resolution landscape-4k --fps {fps}`）。`{fps}` 取上一条的判定结果。

--- a/skills/verysmallwoods-video/references/video.md
+++ b/skills/verysmallwoods-video/references/video.md
@@ -22,12 +22,12 @@
 
 本 skill 在其上只补几条 faceless 没有的**用户口径**：
 
-- **STORYBOARD 必建（铁律）** —— 每期视频都要写 `STORYBOARD.md`，**哪怕只有一个场景**。它是分场景审校与「改一处不重渲全片」的计划账本：一格一个 frame，Studio 渲成联系表可逐帧审、逐帧评论（`.hyperframes/frame-comments.json`）。faceless 里它可能被当作可选或对单场景省略 —— 本 skill 把它收成硬约定，不许跳过。格式见 `/hyperframes-core` 的 `references/storyboard-format.md`。
+- **STORYBOARD 必须创建** —— 每期视频都要写 `STORYBOARD.md`，**哪怕只有一个场景**。格式见 `/hyperframes-core` 的 `references/storyboard-format.md`。
 - **设计** —— 用 Step 0 选定的 preset（默认 `blockframe`），见 `references/designs.md`。
 - **口播稿** —— 按用户的写作/口播偏好写；偏好来自上下文 / 记忆 / 会话里的风格 skill。
 - **旁白** —— 见 `references/audio.md`（自录 或 TTS，由用户选）。
 - **重排到真实 cue** —— 拿到真实音频 + SRT 后，把每帧内部披露重排到真实 cue 时间轴；否则动效走完会定格、旁白在静态画面上继续讲。做法见 `references/audio.md`。
-- **预览 —— 渲染前必问（铁律）** —— `check` 通过后、渲染前，**显式询问用户是否要在 Studio 预览**。用户不要预览 → 跳过，直接进渲染；用户要预览 → 启动 `npx hyperframes preview`（后台常驻），把 Studio URL 交给用户：整片走 `http://localhost:<port>/#project/<name>`，看 storyboard 联系表走 `http://localhost:<port>/?view=storyboard#project/<name>`。等用户看完给反馈（改则读 `frame-comments.json` 走修订轮，见「STORYBOARD 必建」）再渲染。**不要 check 一过就自动渲染。**
+- **预览** —— `check` 通过后、渲染前，**显式询问用户是否要在 Studio 预览**。如需预览，则在用户反馈后，主动阅读 hyperframe 的 comments 文件，充分了解用户的反馈。
 - **字幕不烧进成片** —— 用户在 YouTube 上字幕；成片留底部字幕安全区即可。
 - **帧率** —— 按动效规格智能判定，报给用户，可被指定覆盖。判定后告知用户：选择的帧率，依据以及不同帧率对视频产出的影响。用户明确指定帧率时以用户为准。
 - **渲染** —— 1080p{fps} high 先出保底，磁盘够再出 4K master（`--resolution landscape-4k --fps {fps}`）。`{fps}` 取上一条的判定结果。


### PR DESCRIPTION
## 动机

做较长/多章节视频时，现状是「整支一次生成 HTML → 审 → 出片」，改任一章节都要**重渲整片**。本 PR 把「**分场景制作、单场景调校、再整合**」这套工作流固化进 `verysmallwoods-video` skill，并附一个可跑的示范工程。

## 改动

### 1. skill 约定（`skills/verysmallwoods-video/`）
两条「铁律」口径，补在 faceless 之上的编排层：
- **STORYBOARD 必建** —— 每期视频都写 `STORYBOARD.md`，**含单场景，不许跳过**。它是分场景审校与「改一处不重渲全片」的计划账本（一格一 frame，Studio 渲成联系表可逐帧审 + 逐帧评论 `frame-comments.json`）。
- **预览 · 渲染前必问** —— `check` 通过后、渲染前**显式询问是否 Studio 预览**：不要→跳过直接渲染；要→启动 `preview` 服务、交 URL、等反馈再渲染。**不要 check 一过就自动渲染。**
- `SKILL.md` 骨架 Step 1 / Step 6 同步标注。

### 2. 示范工程（`demo/storyboard-demo/`）
- 宿主 `index.html` + 三个独立子合成场景（hook / concept / cta）+ `STORYBOARD.md`，`hyperframes check` 全绿。
- 演示正确的子合成写法：`<template>` 包裹、`#root` 选择器、宿主/子文件/`__timelines` 三处 `data-composition-id` 对齐 —— 即三个「过静态检查、只在合成渲染时爆」的坑的正解。

### 3. `.gitignore`
忽略 HyperFrames 每工程可再生的生成物（`.hyperframes/` `.thumbnails/` `snapshots/` `renders/`），只提交源文件 —— 与现有 `demo/claude-showcase` 的跟踪方式一致。

## 说明
- 分支基于 `origin/main`，不含本地 `feat/agent-studio-mvp` 的无关提交。
- 仅纳入本轮源文件；未扫入其它未跟踪目录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)